### PR TITLE
Updated info about why win32 rendering isn't possible, corrected debug.bin's description, added .net 5 instructions.

### DIFF
--- a/docs/installing-compatible-software.md
+++ b/docs/installing-compatible-software.md
@@ -33,11 +33,23 @@ set PATH="%PATH%;%PYTHONPATH%"
   - Execute pwsh.exe
   - Profit
 
-## DotNet Core
+## .NET Core
 
   - Download the latest 64 bit dotnet core **runtime** from
     <https://dotnet.microsoft.com/download/dotnet-core>.
   - Unzip and copy the binaries to a flash drive or
+    D:\\DevelopmentFiles\\Dotnet.
+  - Optionally add the dotnet directory to your system PATH via *setx
+    path "%path%;D:\\DotnetPath"* using SSH.
+  - Execute your dotnet core software via "dotnet program.exe" using SSH
+    in the dotnet diectory (or anywhere if you updated your PATH).
+  - Profit
+
+  ## .NET 5
+
+  - Download the latest preview 64 bit dotnet **runtime** from
+    <https://dotnet.microsoft.com/download/dotnet/5.0>.
+  - Unzip and copy the binaries to a flash drive or a location of your choice such as
     D:\\DevelopmentFiles\\Dotnet.
   - Optionally add the dotnet directory to your system PATH via *setx
     path "%path%;D:\\DotnetPath"* using SSH.

--- a/docs/special-ntfs-usb-files.md
+++ b/docs/special-ntfs-usb-files.md
@@ -15,10 +15,10 @@ flash drive to trigger commands on console boot.
 | $NoSurface                  | Folder | Mount drive in HostOS instead of SystemOS.                                                                                                                |
 | $DumpSystemOS               | Folder | SystemOS Memory Dump. The console will ding when the dump is finished. (Host will delete $DumpSystemOS and dump SystemOS's memory into the $Diagnosis.)   |
 | $DumpHostOS                 | Folder | HostOS Memory Dump                                                                                                                                        |
-| $Diagnosis\\debug.bin       | File   | Set debug settings from *debug.bin*                                                                                                                       |
+| $Diagnosis\\debug.bin       | File   | Godbox certificate used for temporary godbox boosting of a Retail.                                                                                                                   |
 | $SystemUpdate\\consoles.txt | File   | Put an empty file consoles.txt on the flashdrive. Console will write its current systemupdate build version to the file on boot. |
-| $ConsoleRegion0             | File   | Only available on Chinese Xbox One. Put an empty file $ConsoleRegion0 on the flashdrive to Disable region lock.|
-| $ConsoleRegion1             | File   | Only available on Chinese Xbox One. Put an empty file $ConsoleRegion1 on the flashdrive to Enable region lock.|
+| $ConsoleRegion0             | File   | Only available on Chinese Xbox One. ~~Put an empty file $ConsoleRegion0 on the flashdrive to Disable region lock.~~ This has now been blocked by an update, see below.|
+| $ConsoleRegion1             | File   | Only available on Chinese Xbox One. ~~Put an empty file $ConsoleRegion1 on the flashdrive to Enable region lock.~~ This has now been blocked by an update, see below.|
 | MSXB_Kiosk                 | File   | Put a special Kiosk XVD on the flashdrive, after booting the console will be locked in Kiosk mode. To exit, power off console and remove the flash drive. |
 
 Note: 

--- a/docs/xbox-ui.md
+++ b/docs/xbox-ui.md
@@ -14,4 +14,4 @@ C:\\Windows\\XboxUI.
 
 ## Win32 process rendering
 
-Unknown how to achieve...
+Generally incompatible due to lack of win32kfull.sys. SystemOS instead uses win32kmin.sys like Windows IoT. Win32kmin lacks windowing support. 


### PR DESCRIPTION
Updated Xbox UI to describe why Win32 rendering is incompatible, corrected debug.bin's description on Special ntfs usb files, and added instructions for installing the .net 5 preview runtime. 