### PR TITLE
add more api endpoints to the dev portal documentation

### DIFF
--- a/docs/dev-portal-api/ext/app-move.md
+++ b/docs/dev-portal-api/ext/app-move.md
@@ -1,0 +1,134 @@
+# Moves an application from one drive to another or manages installation of an application on the target Xbox One development console.   
+
+
+## Cancels the move or install on the target Xbox One development console.
+
+
+**Request**
+
+
+Method      | Request URI
+:------     | :-----
+Delete | /ext/app/move
+
+
+
+**URI parameters**
+
+Parameter      | Format     | Description
+:------     | :-----     | :-----
+| installid       | base64-encoded string | The GUID identifying the move or install which we are querying. This value is returned from a successful GET method starting a move or install.
+
+**Request headers**
+
+- None
+
+**Request body**   
+
+- None
+
+**Response**   
+
+- None
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+200 | Success
+4XX | Error codes
+5XX | Error codes
+
+## Gets the move or install status from an installid.
+
+**Request**
+
+Method      | Request URI
+:------     | :-----
+Get | /ext/app/move
+
+**URI parameters**
+
+Parameter      | Format     | Description
+:------     | :-----     | :-----
+| installid       | base64-encoded string | The GUID identifying the move or install which we are querying. This value is returned from a successful GET method starting a move or install.
+
+
+**Request headers**
+
+- None
+
+**Request body**
+
+- None
+
+**Response**   
+
+- If the call is successful, the service will return a JSON object with the following members.
+
+Member      | Description
+:------     | :-----
+installProgress | Number. This value is a percent between 0 and 100 for the move or installs current progress.
+isRunning | Boolean. If this value is true, the specified move or install is still running. If it is no longer running this value will be false or the method will return an HTTP 404 indicating the install was not found.
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+204 | The request to enable Fiddler was accepted. Fiddler will be enabled the next time the device reboots.
+4XX | Error codes
+5XX | Error codes
+
+## Moves a given application from one drive to another drive.
+
+**Request**
+
+Method      | Request URI
+:------     | :-----
+Post | /ext/app/move
+
+**URI parameters**
+
+Member      | Format     | Description
+:------     | :-----     | :-----
+| packagefullname       | base64-encoded string | The Package Full Name of the package.
+| destinationDrive       | string | The drive to move the package to.
+
+
+**Request headers**
+
+- None
+
+**Request body**   
+
+- None
+
+**Response**   
+
+- If the call is successful, the service will return a JSON object with the following members.
+
+Parameter      | Format     | Description
+:------     | :-----     | :-----
+| installid       | string | The GUID identifying the move or install which we are querying. This value is returned from a successful GET method starting a move or install.
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+204 | The request to disable Fiddler tracing was successful. Tracing will be disabled on the next reboot of the device.
+4XX | Error codes
+5XX | Error codes
+
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft

--- a/docs/dev-portal-api/ext/app-packagemanager-era-available.md
+++ b/docs/dev-portal-api/ext/app-packagemanager-era-available.md
@@ -1,4 +1,4 @@
-# unregistered packages. API reference
+# Determines whether there are any apps ready to be registered on the Title Scratch drive or in the DeveloperFiles LooseApps folder.
 
 Gets a Boolean value that indicates whether there are any apps ready to be registered on the Title Scratch drive or in the DeveloperFiles LooseApps folder.
 

--- a/docs/dev-portal-api/ext/app-packagemanager-era-check copy.md
+++ b/docs/dev-portal-api/ext/app-packagemanager-era-check copy.md
@@ -1,0 +1,48 @@
+# Determines whether the specified AppXManifest is for an ERA title or a UWP application.
+Gets a Boolean value that indicates whether the specified AppXManifest is for an ERA title.
+
+**Request**
+
+Method      | Request URI
+:------     | :------
+POST | (/ext/app/packagemanager/era/check
+<br />
+
+**URI parameters**
+
+ - None
+
+**Request headers**
+
+- None
+
+**Request body**
+
+- The request must contain the multi-part conforming HTTP body of the AppXManifest.xml file.
+
+###Response
+
+**Response body**
+
+If the call is successful, the service will return a JSON object with the following members.
+Member      | Description
+:------     | :-----
+isEra | Boolean. If this value is true, the specified AppXManifest is for an ERA title. If this value is false, the specified AppXManifest is for a UWP app.
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+200 | Success
+4XX | Error codes
+5XX | Error codes
+
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft

--- a/docs/dev-portal-api/ext/app-packagemanager-era-register-streaming.md
+++ b/docs/dev-portal-api/ext/app-packagemanager-era-register-streaming.md
@@ -1,0 +1,58 @@
+# Starts the streaming install of an XVC from a network share or local drive on the console.
+
+
+**Request**
+
+Method      | Request URI
+:------     | :------
+POST | (/ext/app/packagemanager/era/streaming
+<br />
+
+**URI parameters**
+
+Parameter      |  Format |  Description
+:------     | :-----  | :-----
+xvcfilepath  | base64-encoded string | The network share or console local path to the XVC to be installed.
+deploydrive | string | Optional deploy drive.
+Languages | string  | Optional language specifiers.
+Devices | string | Optional devices specifiers.
+ContentTypes | string | Optional contentTypes specifiers
+Tags | string | Optional tags specifiers.
+OddSim | Whether or not ODD simulation should be used.
+
+**Request headers**
+
+- None
+
+**Request body**
+
+- Optionally this API can take a “username” and “password” optional parameter in JSON format in the request body if credentials are needed to access the network share.
+
+###Response
+
+**Response body**
+
+If the call is successful, the service will return a JSON object with the following members.
+
+Member      |  Format |  Description
+:------     | :-----  | :-----
+ContentId  | string | A GUID indicating the ContentId of this package.
+InstallId | string | A GUID which will identify the install for future calls to cancel or retrieve the status of the install.
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+200 | Success
+4XX | Error codes
+5XX | Error codes
+
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft

--- a/docs/dev-portal-api/ext/app-packagemanager-era-register.md
+++ b/docs/dev-portal-api/ext/app-packagemanager-era-register.md
@@ -1,0 +1,49 @@
+# Registers the app in the specified loose folder, or registers an app on a specified drive by the package full name.
+
+
+**Request**
+
+Method      | Request URI
+:------     | :------
+POST | /ext/app/packagemanager/era/register
+<br />
+
+**URI parameters**
+
+Parameter      |  Format |  Description
+:------     | :-----  | :-----
+Folder  | base64-encoded string | The destination folder name of the package to be registered. This folder must exist on the Title Scratch drive on the console. This folder name should be base64-encoded, as it may contain path separators if the folder is in a subfolder on the drive. Required if registering a loose folder.
+packagefullname | base64-encoded string | The Package Full Name of the package. Required if registering an app on a drive.
+deploydrive | string  | The drive where the package resides. Required if registering an app on a drive.
+
+**Request headers**
+
+- None
+
+**Request body**
+
+- None
+
+###Response
+
+**Response body**
+
+- Unknown
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+200 | Success
+4XX | Error codes
+5XX | Error codes
+
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft

--- a/docs/dev-portal-api/ext/frontpanel.md
+++ b/docs/dev-portal-api/ext/frontpanel.md
@@ -1,0 +1,28 @@
+# Remotely controls a front panel for an Xbox One X Devkit.
+
+
+**Request**
+
+Method      | Request URI
+:------     | :------
+WebSocket | /ext/frontpanel
+<br />
+
+
+**Send messages**
+
+Strings can be send indicating that front panel buttons should be pressed. The strings should be from the following set:
+
+Up, Down, Left, Right, or Select to control navigation One, Two, Three, Four, Five to press one of the five buttons Switch to simulate a long press of the Select button (toggling between Title and System mode).
+
+
+**Recieve messages**
+
+The websocket will return an image buffer which an be processed to show the contents of the front panel display. The buffer is send in 4bpp.
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft

--- a/docs/dev-portal-api/ext/unattendedsetup-apply.md
+++ b/docs/dev-portal-api/ext/unattendedsetup-apply.md
@@ -1,0 +1,45 @@
+# Sets a script to the boot script for the target Xbox One development console.
+
+
+**Request**
+
+Method      | Request URI
+:------     | :------
+POST | /ext/unattendedsetup/apply
+<br />
+
+**URI parameters**
+
+- None
+
+**Request headers**
+
+- None
+
+**Request body**
+
+Multi-part conforming HTTP body that contains the script file to apply.
+
+###Response
+
+**Response body**
+
+- Unknown
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+200 | Success
+4XX | Error codes
+5XX | Error codes
+
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft

--- a/docs/dev-portal-api/ext/unattendedsetup-configure.md
+++ b/docs/dev-portal-api/ext/unattendedsetup-configure.md
@@ -1,0 +1,91 @@
+# Provides access to configuration data for how scripts are run. 
+
+## Retrieves configuration data for how scripts are run.
+
+**Request**
+
+Method      | Request URI
+:------     | :-----
+Get | /ext/unattendedsetup/configure
+
+**URI parameters**
+
+- None
+
+
+**Request headers**
+
+- None
+
+**Request body**
+
+- None
+
+**Response**   
+
+If the call is successful, the service will return a JSON object with the following members.
+
+Member      | Description
+:------     | :-----
+RunOobeScript | Boolean value that indicates whether we should run any one-time script on the next boot (expected script name is oobe.cmd).
+BlockUsbScript | Boolean value that indicates whether we should block unattended scripts from running when on a USB device.
+SkipAbortToast | Boolean value that indicates whether we should run scripts immediately on boot instead of waiting for an abort window.
+BlockAllScripts | Boolean value that indicates whether we should block unattended scripts from running.
+HasScript | Boolean value that indicates whether the target console currently has a boot script.
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+204 | The request to enable Fiddler was accepted. Fiddler will be enabled the next time the device reboots.
+4XX | Error codes
+5XX | Error codes
+
+## Sets configuration data for how scripts are run.
+
+**Request**
+
+Method      | Request URI
+:------     | :-----
+Post | /ext/unattendedsetup/configure
+
+**URI parameters**
+
+- None
+
+**Request headers**
+
+- None
+
+**Request body**   
+
+The request must contain a JSON body that has the following members.
+
+RunOobeScript | Boolean value that indicates whether we should run any one-time script on the next boot (expected script name is oobe.cmd).
+BlockUsbScript | Boolean value that indicates whether we should block unattended scripts from running when on a USB device.
+SkipAbortToast | Boolean value that indicates whether we should run scripts immediately on boot instead of waiting for an abort window.
+BlockAllScripts | Boolean value that indicates whether we should block unattended scripts from running.
+
+**Response**   
+
+- None
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+204 | The request to disable Fiddler tracing was successful. Tracing will be disabled on the next reboot of the device.
+4XX | Error codes
+5XX | Error codes
+
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft

--- a/docs/dev-portal-api/ext/unattendedsetup-default.md
+++ b/docs/dev-portal-api/ext/unattendedsetup-default.md
@@ -1,0 +1,117 @@
+# Provides access to the boot script on the target Xbox One development console.  
+
+
+## Deletes the boot script on the target Xbox One development console.
+
+
+**Request**
+
+
+Method      | Request URI
+:------     | :-----
+Delete | /ext/unattendedsetup/default
+
+
+
+**URI parameters**
+
+- None
+
+**Request headers**
+
+- None
+
+**Request body**   
+
+- None
+
+**Response**   
+
+- None
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+200 | Success
+4XX | Error codes
+5XX | Error codes
+
+## Retrieves the boot script on the target Xbox One development console
+
+**Request**
+
+Method      | Request URI
+:------     | :-----
+Get | /ext/unattendedsetup/default
+
+**URI parameters**
+
+- None
+
+
+**Request headers**
+
+- None
+
+**Request body**
+
+- None
+
+**Response**   
+
+If the call is successful, the service will return the script file as a multi-part conforming HTTP body.
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+204 | The request to enable Fiddler was accepted. Fiddler will be enabled the next time the device reboots.
+4XX | Error codes
+5XX | Error codes
+
+## Runs the boot script on the target Xbox One development console.
+
+**Request**
+
+Method      | Request URI
+:------     | :-----
+Post | /ext/unattendedsetup/default
+
+**URI parameters**
+
+- None
+
+**Request headers**
+
+- None
+
+**Request body**   
+
+- None
+
+**Response**   
+
+- None
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+204 | The request to disable Fiddler tracing was successful. Tracing will be disabled on the next reboot of the device.
+4XX | Error codes
+5XX | Error codes
+
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft

--- a/docs/dev-portal-api/ext/unattendedsetup-quickaction.md
+++ b/docs/dev-portal-api/ext/unattendedsetup-quickaction.md
@@ -1,0 +1,105 @@
+# Manages the scripts configured for the front panel display buttons on an Xbox One X Devkit.  
+
+## Changes the script assigned to one of the front panel buttons or runs one of the front panel scripts on the target Xbox One development console.
+
+**Request**
+
+Method      | Request URI
+:------     | :-----
+Post | /ext/unattendedsetup/quickaction
+
+**URI parameters**
+
+Method      | Format  | Description
+:------     | :-----    | :-----
+ButtonNumber | number | Optional number of the front panel button we are dealing with. If this is not provided, this is a request to add a new custom script to the console
+Name | base64-encoded string | Optional string indicating the name of the script we are applying to a button. If this is not provided then the current script associated with ButtonNumber is run instead.
+IsBuiltIn | boolean | Optional bool indicating whether or not the script we are applying is a built in script provided with the system or a custom script previously added to the console by the user.
+
+**Request headers**
+
+- None
+
+**Request body**
+
+- None
+
+**Response**   
+
+If the call is successful and the request was to run the action associated with a button, the service will return a JSON object with the following members:
+
+Method      | Format  | Description
+:------     | :-----    | :-----
+Output | string | The output from running
+
+If the call was to apply a script to a button or add a new custom script, there is no response body.
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+204 | The request to enable Fiddler was accepted. Fiddler will be enabled the next time the device reboots.
+4XX | Error codes
+5XX | Error codes
+
+## Retrieves the information about the scripts applied to and available to the front panel buttons on the target Xbox One development console.
+
+**Request**
+
+Method      | Request URI
+:------     | :-----
+Get | /ext/app/quickaction
+
+**URI parameters**
+
+Method      | Format  | Description
+:------     | :-----    | :-----
+Name | base64-encoded string | Optional string indicating we want the contents of a script.
+IsBuiltIn | boolean | Optional bool indicating if this is a built in script provided with the system or a custom script added to the console by the user.
+
+**Request headers**
+
+- None
+
+**Request body**   
+
+- None
+
+**Response**   
+
+If the call is successful and a script was requested by name, the service will return the script file as a multi-part conforming HTTP body.
+
+If a script was not requested, the service will return a JSON object with the following members:
+
+Method      | Format  | Description
+:------     | :-----    | :-----
+IsAvailable | boolean | Whether or not front panel scripts are available on this console. This will be true for the Xbox One X Devkit and false for other devkit types. If this is false, no other members will be returned.
+QuickActions | Array of JSON objects | An array containing all the available quick actions on this console.
+QuickActions | Array of JSON objects | An array containing all the available quick actions on this console. | Array of JSON objects | An array containing the 5 quick actions which are assigned to the front panel buttons on this console.
+
+Quick actions JSON objects have the following members:
+
+Method      | Format  | Description
+:------     | :-----    | :-----
+Name | base64-encoded string | The name of the script on the console.
+IsBuiltIn | boolean | Whether or not this is a built in script provided with the system or a custom script added to the console by the user.
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+204 | The request to disable Fiddler tracing was successful. Tracing will be disabled on the next reboot of the device.
+4XX | Error codes
+5XX | Error codes
+
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft

--- a/docs/dev-portal-api/ext/unattendedsetup-test.md
+++ b/docs/dev-portal-api/ext/unattendedsetup-test.md
@@ -1,0 +1,45 @@
+# Tests a script by running it on the target Xbox One development console.
+
+
+**Request**
+
+Method      | Request URI
+:------     | :------
+POST | /ext/unattendedsetup/test
+<br />
+
+**URI parameters**
+
+- None
+
+**Request headers**
+
+- None
+
+**Request body**
+
+Multi-part conforming HTTP body that contains the script file to run. 
+
+###Response
+
+**Response body**
+
+If the call is successful, the service will return a JSON object with the script output and status code.
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+200 | Success
+4XX | Error codes
+5XX | Error codes
+
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft

--- a/docs/dev-portal-api/ext/update-remote.md
+++ b/docs/dev-portal-api/ext/update-remote.md
@@ -1,0 +1,59 @@
+# Gets a Boolean value that indicates whether the specified AppXManifest is for an ERA title.
+
+
+**Request**
+
+Method      | Request URI
+:------     | :------
+POST | /ext/update/remote
+<br />
+
+**URI parameters**
+
+Parameter      |  Format |  Description
+:------     | :-----  | :-----
+networkshare  | base64-encoded string | The network share location of the system update packages. This network share should be base64-encoded.
+
+**Request headers**
+
+- None
+
+**Request body**
+
+if credentials are required to access the network share, the request must contain a JSON body that contains optional username and password parameters and a Boolean parameter AllowSameBuild that indicates whether the recovery should be allowed to proceed even if the console is already on this build. The JSON should also contain an array named RecoverOptions which contains ParamName to ParamValue key-value pairs specifying the following update options:
+
+- X-UpdateDownloadPolicy : 1 or 0, where 0 means the console will show an update prompt and 1 supresses that prompt. 
+
+- X-ForceFactoryReset : bool indicating if a factory reset should be performed.
+
+- X-FactoryResetOptions : 0xdededede if performing a factory reset, 0 otherwise. 
+
+- X-HostName : should be set to `“<save>”` to preserve the hostname, even in factory reset scenarios. 
+
+- X-InhibitIdleTimeout : bool indicating if the screen dim settings should be respected while updating. 
+
+- X-SandboxId : the sandbox id to set as part of the recovery. 
+
+###Response
+
+**Response body**
+
+- Unknown
+
+**Status code**
+
+This API has the following expected status codes.
+
+HTTP status code      | Description
+:------     | :-----
+200 | Success
+4XX | Error codes
+5XX | Error codes
+
+
+**Available device families**
+
+* Windows Xbox
+
+**Credits**
+Microsoft


### PR DESCRIPTION
Add the dev portal api urls for:
Deployment, Remote Recovery, unattended setup and front panel