### PR TITLE
fix device portal links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ See [FAQ](faq) for frequently asked questions.
   - [Security Processor](security-processor)
   - [Special NTFS USB files](special-ntfs-usb-files)
   - [Telemetry](telemetry)
-  - [Xbox Device Portal](xbox-device-portal)
+  - [Xbox Device Portal](device-portal)
   - [Xbox Game Disc](xbox-game-disc)
   - [Xbox Operating System](xbox-operating-system)
   - [Xbox UI](xbox-ui)


### PR DESCRIPTION
Fixed the link to the device portal from the main index page being wrong