### PR TITLE
Document the "Brittlebush" codename

### DIFF
--- a/docs/codenames.md
+++ b/docs/codenames.md
@@ -1,11 +1,13 @@
 # Codenames
 
-This page contains a list of known codenames for software, accesories, or other components of the Xbox one.
+This page contains a list of known internal codenames for hardware, software, accesories, or other components of the Xbox one.
 
-| Codename   |      Product / App Name     | Category |  Description |
+| Codename   |      Product / App Name     | Category |  Description or Comments |
 |----------|-------------|------|------|
-| Nui / nuisensor | Kinect | Hardware | Internal name for Kinect, used in official APIs and drivers |
+| Nui / nuisensor | Kinect | Hardware | Internal name for Kinect, still used in official APIs and drivers |
 | Petra  | Presumably, a codename of an earlier Kinect prototype hardware version | Hardware | N/A |
 | Nazca  | Presumably, a codename of an earlier Kinect prototype hardware version | Hardware | N/A |
 | Ameri  | Presumably, a codename of an earlier Kinect prototype hardware version | Hardware | N/A |
 | Zurich | [Xbox One Digital Tv Tuner Adapter](https://www.amazon.de/Xbox-One-Digital-TV-Tuner/dp/B00E97HVJI)   |  Hardware | N/A |
+| Brittlebush | [XDK Transfer Device]([https://www.amazon.de/Xbox-One-Digital-TV-Tuner/dp/B00E97HVJI](https://xosft.dev/wiki/xdk_transfer/))   |  Hardware | N/A |
+ 

--- a/docs/codenames.md
+++ b/docs/codenames.md
@@ -9,5 +9,5 @@ This page contains a list of known internal codenames for hardware, software, ac
 | Nazca  | Presumably, a codename of an earlier Kinect prototype hardware version | Hardware | N/A |
 | Ameri  | Presumably, a codename of an earlier Kinect prototype hardware version | Hardware | N/A |
 | Zurich | [Xbox One Digital Tv Tuner Adapter](https://www.amazon.de/Xbox-One-Digital-TV-Tuner/dp/B00E97HVJI)   |  Hardware | N/A |
-| Brittlebush | [XDK Transfer Device]([https://www.amazon.de/Xbox-One-Digital-TV-Tuner/dp/B00E97HVJI](https://xosft.dev/wiki/xdk_transfer/))   |  Hardware | N/A |
+| Brittlebush | [XDK Transfer Device](https://xosft.dev/wiki/xdk_transfer/)   |  Hardware | N/A |
  


### PR DESCRIPTION
Someone on Twitter adquired a bunch of XDK Transfer devices with hardware revision DV2 and the codename Brittlebush on them