### PR TITLE
Made link formatting consistent throughout pages

### DIFF
--- a/docs/bootanimation.md
+++ b/docs/bootanimation.md
@@ -1,7 +1,7 @@
 # Bootanimation
 Bootanimation is the Xbox loading animation showing at bootup of the console.
 
-The file is stored in [XBFS](../xbox-boot-filesystem) as bootanim.dat.
+The file is stored in [XBFS](xbox-boot-file-system.md) as bootanim.dat.
 
 It uses a proprietary format, likely specific to the AMD GPU.
 

--- a/docs/certificates.md
+++ b/docs/certificates.md
@@ -8,7 +8,7 @@ determining the capabalities to enable.
 ## Console Certificate
 
 Per-console certificate to verify and define the device. Stored in
-**sp_s.cfg** (offset: 0x5400) inside [XBFS](../xbox-boot-file-system).
+**sp_s.cfg** (offset: 0x5400) inside [XBFS](xbox-boot-file-system.md).
 
 Total Size: 0x400 bytes
 
@@ -38,8 +38,8 @@ Total Size: 0x400 bytes
 ## Boot Capability Certificate
 
 Used to determine what type of developer features the console can use.
-Stored in **certkeys.bin** inside [XBFS](../xbox-boot-file-system).
-Also check out [Devkit types](../devkit-types).
+Stored in **certkeys.bin** inside [XBFS](xbox-boot-file-system.md).
+Also check out [Devkit types](devkit-types.md).
 
 ### Format
 Total Size: 0x180 bytes

--- a/docs/dev-portal-api/device-portal-pages.md
+++ b/docs/dev-portal-api/device-portal-pages.md
@@ -1,6 +1,6 @@
 # Device Portal pages
 
-The Xbox Device Portal provides a set of standard pages similar to what's available on the Windows Device Portal, as well as several pages that are unique. For detailed descriptions of the former, see [Windows Device Portal overview](../debug-test-perf/device-portal.md). The following sections describe the pages that are unique to the Xbox Device Portal.
+The Xbox Device Portal provides a set of standard pages similar to what's available on the Windows Device Portal, as well as several pages that are unique. For detailed descriptions of the former, see [Windows Device Portal overview](https://learn.microsoft.com/en-us/windows/uwp/debug-test-perf/device-portal). The following sections describe the pages that are unique to the Xbox Device Portal.
 
 ## Home
 
@@ -12,7 +12,7 @@ Under **Xbox Live test accounts**, you can manage the accounts associated with y
 
 ## Xbox Live (Game saves)
 
-Both the Windows Device Portal and the Xbox Device Portal have an **Xbox Live** page. However, the Xbox Device Portal has a unique section, **Xbox Live game saves**, where you can save data for games installed on your Xbox. Enter the **Service Configuration ID (SCID)** (see [Xbox Live service configuration](/gaming/xbox-live/xbox-live-service-configuration.md#get-your-ids) for more information), **Membername (MSA)**, and **Package Family Name (PFN)** associated with the title and game save, browse for the **Input File (.json or .xml)**, and then select one of the buttons (**Reset**, **Import**, **Export**, and **Delete**) to manipulate the save data.
+Both the Windows Device Portal and the Xbox Device Portal have an **Xbox Live** page. However, the Xbox Device Portal has a unique section, **Xbox Live game saves**, where you can save data for games installed on your Xbox. Enter the **Service Configuration ID (SCID)** (see [Xbox Live service configuration](https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/live/test-release/portal-config/live-service-config-ids-mp#get-your-ids) for more information), **Membername (MSA)**, and **Package Family Name (PFN)** associated with the title and game save, browse for the **Input File (.json or .xml)**, and then select one of the buttons (**Reset**, **Import**, **Export**, and **Delete**) to manipulate the save data.
 
 In the **Generate** section, you can generate dummy data and save to the specified input file. Simply enter the **Containers (default 2)**, **Blobs (default 3)**, and **Blob Size (default 1024)**, and select **Generate**.
 
@@ -32,7 +32,7 @@ Once enabled, in the Xbox Device Portal, you can **Stop**, **Clear**, and **Save
 
 ## Network (Fiddler tracing)
 
-The **Network** page in the Xbox Device Portal is almost identical to the **Networking** page in the Windows Device Portal, with the exception of **Fiddler tracing**, which is unique to the Xbox Device Portal. This allows you to run Fiddler on your PC to log and inspect HTTP and HTTPS traffic between your Xbox One and the internet. See [How to use Fiddler with Xbox One when developing for UWP](../xbox-apps/uwp-fiddler.md) for more information.
+The **Network** page in the Xbox Device Portal is almost identical to the **Networking** page in the Windows Device Portal, with the exception of **Fiddler tracing**, which is unique to the Xbox Device Portal. This allows you to run Fiddler on your PC to log and inspect HTTP and HTTPS traffic between your Xbox One and the internet. See [How to use Fiddler with Xbox One when developing for UWP](https://learn.microsoft.com/en-us/windows/uwp/xbox-apps/uwp-fiddler) for more information.
 
 ![Network](images/device-portal-xbox-19.png)
 
@@ -156,4 +156,4 @@ This is a blank workspace, which you can customize to your liking. You can use t
 
 On the **Game event data** page, you can view a realtime graph that streams in the number of Event Tracing for Windows (ETW) game events currently recorded on your Xbox One. If there are game events recorded on the system, you can also view details (event name, event occurrence, and the game title) describing each event in a data table below the data graph. The table is only available if there are events recorded.
 
-![Game event data](images/device-portal-xbox-22.PNG)
+![Game event data](images/device-portal-xbox-22.png)

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,4 +12,4 @@ A command-line tool for manipulating Xbox One XVD & XVC files.
 
 ## Resources
 
-[Installing Compatible software](../installing-compatible-software)
+[Installing Compatible software](installing-compatible-software.md)

--- a/docs/devkit-types.md
+++ b/docs/devkit-types.md
@@ -3,11 +3,11 @@
 
 # Devkits
 
-Most Xbox One devkits start out life as an off the shelf retail console (with the exception of special SP kits I will cover below). An Xbox One's devkit type and abilities or capabilities are defined by a file stored on the flash called "certkeys.bin." - certkeys.bin is referred to as the [Capability Certificate](../certificates) by the Platform Security Processor ([PSP](../security-processor)) and it will be referred to as such from here on out.
+Most Xbox One devkits start out life as an off the shelf retail console (with the exception of special SP kits I will cover below). An Xbox One's devkit type and abilities or capabilities are defined by a file stored on the flash called "certkeys.bin." - certkeys.bin is referred to as the [Capability Certificate](certificates.md) by the Platform Security Processor ([PSP](security-processor.md)) and it will be referred to as such from here on out.
 
 It should be noted that capability certificates are locked to a particular console via the SOCID (Reported as Console ID in settings). The entire certificate is then signed to prevent tampering.
 
-A capability certificate defines what capabilities an Xbox One console is allowed to enable (This is regulated via the [PSP](../security-processor) and to a degree, HostOS.) The capabilities range from enabling Devmode and the respective developer services, ignoring requests to blowing e-fuses, HostOS telnet and Retail debugging, and much more.
+A capability certificate defines what capabilities an Xbox One console is allowed to enable (This is regulated via the [PSP](security-processor.md) and to a degree, HostOS.) The capabilities range from enabling Devmode and the respective developer services, ignoring requests to blowing e-fuses, HostOS telnet and Retail debugging, and much more.
 
 ## Devkit types
 There are different types of devkits
@@ -24,8 +24,8 @@ There are different types of devkits
 
 ## Certificates
 
-See [Certificates](../certificates)
+See [Certificates](certificates.md)
 
 ## Godbox Certificate
 
-A magical capability certificate ([$Diagnosis/debug.bin on a NTFS USB](../special-ntfs-usb-files)) that will temporaily activate a retail console as a limited Godbox for 24 hours. Kernel/User-Mode debugging is only possible on SystemOS and GameOS, not HostOS, and the temporary kit requires authentication against Live.
+A magical capability certificate ([$Diagnosis/debug.bin on a NTFS USB](special-ntfs-usb-files.md)) that will temporaily activate a retail console as a limited Godbox for 24 hours. Kernel/User-Mode debugging is only possible on SystemOS and GameOS, not HostOS, and the temporary kit requires authentication against Live.

--- a/docs/eMMC---Flash.md
+++ b/docs/eMMC---Flash.md
@@ -2,7 +2,7 @@
 The flash chip is accessed via an eMMC controller.
 
 ## Filesystem
-See [XBFS](../xbox-boot-file-system).
+See [XBFS](xbox-boot-file-system.md).
 
 ## Flash chips
 - SK Hynix H26M42003GMR 8GB eMMC NAND Flash (Xbox One)
@@ -41,7 +41,7 @@ Place a **200-300 Ohm** resistor between **J4E1.1** and **TP4E1**
 
 ![Enabling SMC_RESET](emmc-flash/3_durango_read_nand_smcreset.png)
 
-Disconnect the SMC clock from the [Southbridge](../southbridge) by removing **R4D2**.
+Disconnect the SMC clock from the [Southbridge](southbridge.md) by removing **R4D2**.
 Save the resistor as it is needed for the Xbox One to function. If you do lose it then a solder bridge should work as the value is 0 Ohms.
 
 ![Disconnecting SMC clock](emmc-flash/4_durango_read_nand_r4d2.png)

--- a/docs/exploits.md
+++ b/docs/exploits.md
@@ -3,18 +3,18 @@
 ## Software
 
 ### Retail
-- [HostOS - External VBI loading](../external-vbi-loading) (19.09.2019)
-- [SystemOS Symbolic Link Exploit](../file-explorer-symbolic-links) - Access restricted/encrypted volumes using the Xbox File Explorer (02.06.2017)
-- [SystemOS Microsoft Edge - chakra.dll Info Leak](../ms-edge-exploit-cve-2016-7200) (30.03.2017)
-- [SystemOS Microsoft Edge - File System Access](../Edge-Browser-File-System-Exposure) (XX.XX.20XX)
+- [HostOS - External VBI loading](external-vbi-loading.md) (19.09.2019)
+- [SystemOS Symbolic Link Exploit](file-explorer-symbolic-links.md) - Access restricted/encrypted volumes using the Xbox File Explorer (02.06.2017)
+- [SystemOS Microsoft Edge - chakra.dll Info Leak](ms-edge-exploit-cve-2016-7200.md) (30.03.2017)
+- [SystemOS Microsoft Edge - File System Access](Edge-Browser-File-System-Exposure.md) (XX.XX.20XX)
 - [SystemOS Remote Code Execution - Xbox Live Messaging](https://titleos.dev/xploring-xbox/) (XX.XX.2019)
 - [Browser access while offline](browser-access-while-offline.md)
 
 ### Development mode
-- [SystemOS Read/Write overlay for System.xvd](../devmode-systemxvd-read-write) (31.07.2019)
-- [SystemOS Elevation of privileges via UnattendedUtilities](../devmode-unattended-utilities) (11.06.2019)
-- [SystemOS Elevation of privileges via VSProfiling account](../devmode-priv-escalation-vsprofiling) (09.09.2018)
-- [SystemOS shell access](../setup-dev-mode#using-ssh) (09.09.2018)
+- [SystemOS Read/Write overlay for System.xvd](devmode-systemxvd-read-write.md) (31.07.2019)
+- [SystemOS Elevation of privileges via UnattendedUtilities](devmode-unattended-utilities.md) (11.06.2019)
+- [SystemOS Elevation of privileges via VSProfiling account](devmode-priv-escalation-vsprofiling.md) (09.09.2018)
+- [SystemOS shell access](setup-dev-mode.md#using-ssh) (09.09.2018)
 
 ## Hardware
 - None so far

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ Named pipes / special kernel broker drivers are used to push data between the OS
 The Xbox One is known to currently use a driver common on all OS VMs known as "XVIO" which appear to use shared memory ring buffers to communicate between the host and guest virtual machines.
 
 ## Can we draw standard Win32 UI? ##
-The possibility of "escaping" the UWP sandbox thats originally targeted at homebrew developers is tempting and of course delivers a bigger potential for developers to port applications more easily. However, as the rendering is done in a non-Win32-conform way, it is also a challenge to achieve displaying such Win32 GUI application. See [XboxUI](../xbox-ui) for further info. 
+The possibility of "escaping" the UWP sandbox thats originally targeted at homebrew developers is tempting and of course delivers a bigger potential for developers to port applications more easily. However, as the rendering is done in a non-Win32-conform way, it is also a challenge to achieve displaying such Win32 GUI application. See [XboxUI](xbox-ui.md) for further info. 
 Traditional Win32 rendering is very unlikely to be possible on SystemOS. Like Windows IoT, the System VM makes use of the win32kmin.sys windowing driver rather than the full win32k.sys or win32kfull.sys employed by Client and Desktop, which doesn't support rendering more than one window at a time. Microsoft has tricks to supplement this (which can be seen in cases of the guide and dash being open, etc), however they are not known at this time. 
 
 ## Where and how do we get the keys? ##
@@ -44,7 +44,7 @@ Different keys are used for the following purposes:
 - Games / apps (CIK / Content integrity keys)
 
 ## Certificates ##
-There are at least two major certificates utilized for generic usage: Console certificate and Boot capability certificate. Of course they are signed with an RSA key and therefore cannot be modified. For further info see [Certificates](../certificates).
+There are at least two major certificates utilized for generic usage: Console certificate and Boot capability certificate. Of course they are signed with an RSA key and therefore cannot be modified. For further info see [Certificates](certificates.md).
 
 ## Reset Glitch hack? ##
 A power glitch hack that made hacking the Xbox 360 feasible for the public was an unforseen technique that led to breaking the secure boot chain of trust [Info](https://recon.cx/2015/slides/recon2015-13-colin-o-flynn-Glitching-and-Side-Channel-Analysis-for-All.pdf) You could say that the designers of the console, that appeared in the end of 2005, were not aware of this possibility. Obviously technique and mitigations evolved since that time, so it is a lot harder to pull off such an attack on the modern Xbox One console. It is expected to have a lot of mitigations implemented (for example: timing checks, excessive data validity checks etc.) 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,43 +7,43 @@ Welcome to the Xbox One Research wiki\!
 This is a place where information about the Xbox One console can be
 shared. Things are currently slow but will be adding when we can.
 
-See [FAQ](faq) for frequently asked questions.
+See [FAQ](faq.md) for frequently asked questions.
 
 ## Getting started
 
 ### General
-  - [Exploits](exploits)
-  - [Codenames](codenames)
+  - [Exploits](exploits.md)
+  - [Codenames](codenames.md)
 
 ### Hardware
-  - [Console revisions](console-revisions)
-  - [CPU](cpu)
-  - [Southbridge](southbridge)
-  - [eMMC / Flash](eMMC---Flash)
-  - [Wifi](wifi)
-  - [Ethernet](ethernet)
-  - [Optical Disc Drive](optical-disc-drive)
-  - [RF unit](rf-unit)
-  - [XDK Transfer device](xdk_transfer)
+  - [Console revisions](console-revisions.md)
+  - [CPU](cpu.md)
+  - [Southbridge](southbridge.md)
+  - [eMMC / Flash](eMMC---Flash.md)
+  - [Wifi](wifi.md)
+  - [Ethernet](ethernet.md)
+  - [Optical Disc Drive](optical-disc-drive.md)
+  - [RF unit](rf-unit.md)
+  - [XDK Transfer device](xdk_transfer.md)
 
 ### Software
-  - [Bootanimation](bootanimation)
-  - [Bootloaders](bootloaders)
-  - [Certificates](certificates)
-  - [Flash (XBFS)](xbox-boot-file-system)
-  - [Hard drive](harddrive)
-  - [Security Processor](security-processor)
-  - [Special NTFS USB files](special-ntfs-usb-files)
-  - [Telemetry](telemetry)
-  - [Protocol URIs (Deep links)](protcol-URIs)
-  - [ODD Update Logs](optical-disc-drive/odd-firmware-update-log)
-  - [Xbox Device Portal](device-portal)
-  - [Xbox Game Disc](xbox-game-disc)
-  - [Xbox Operating System](xbox-operating-system)
-  - [Xbox UI](xbox-ui)
-  - [Xbox WinRT](winmd)
-  - [XCRDUtil](xcrdutil)
-  - [DefaultApp](default-app)
+  - [Bootanimation](bootanimation.md)
+  - [Bootloaders](bootloaders.md)
+  - [Certificates](certificates.md)
+  - [Flash (XBFS)](xbox-boot-file-system.md)
+  - [Hard drive](harddrive.md)
+  - [Security Processor](security-processor.md)
+  - [Special NTFS USB files](special-ntfs-usb-files.md)
+  - [Telemetry](telemetry.md)
+  - [Protocol URIs (Deep links)](protcol-URIs.md)
+  - [ODD Update Logs](optical-disc-drive/odd-firmware-update-log.md)
+  - [Xbox Device Portal](device-portal.md)
+  - [Xbox Game Disc](xbox-game-disc.md)
+  - [Xbox Operating System](xbox-operating-system.md)
+  - [Xbox UI](xbox-ui.md)
+  - [Xbox WinRT](winmd.md)
+  - [XCRDUtil](xcrdutil.md)
+  - [DefaultApp](default-app.md)
 
 ### Xbox Live
   - [Xbox Live Error Codes](xbox-live/hresult-error-codes.md)
@@ -52,17 +52,17 @@ See [FAQ](faq) for frequently asked questions.
   - [Update CDN APIs and Downloads](xbox-live/update-cdn.md)
 
 ### File formats
-  - [Xbox Virtual Drives (XVD)](xbox-virtual-drive)
-  - [XVI](xvi)
-  - [XCT](xct)
-  - [VBI](vbi)
-  - [Savegames](savegames)
+  - [Xbox Virtual Drives (XVD)](xbox-virtual-drive.md)
+  - [XVI](xvi.md)
+  - [XCT](xct.md)
+  - [VBI](vbi.md)
+  - [Savegames](savegames.md)
 
 ### Dev Mode
-  - [Devkit types](devkit-types)
-  - [Setting up your console](setup-dev-mode)
-  - [Installing Compatible Software](installing-compatible-software)
-  - [Creating your own Windows User](creating-a-win-user)
+  - [Devkit types](devkit-types.md)
+  - [Setting up your console](setup-dev-mode.md)
+  - [Installing Compatible Software](installing-compatible-software.md)
+  - [Creating your own Windows User](creating-a-win-user.md)
   - [XTF APIs](xtf-apis.md)
 
 ## Important

--- a/docs/optical-disc-drive.md
+++ b/docs/optical-disc-drive.md
@@ -4,7 +4,7 @@
 # Xbox Optical disc drive
 ## Game discs
 
-Xbox One game discs are called [XGD4](xbox-game-disc) (Xbox Game Disc Version 4).
+Xbox One game discs are called [XGD4](xbox-game-disc.md) (Xbox Game Disc Version 4).
 
 ## Drive models
 

--- a/docs/xbox-operating-system.md
+++ b/docs/xbox-operating-system.md
@@ -17,7 +17,7 @@ that implement Microsoft's Xbox Virtual Machine stack.
 
 | Partition Name | Mount Point as seen by HostOS | Notes                                                                                                                                                                                                                 |
 | -------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Internal Flash | F:\\        | The flash does not contain a normal file system, it is using the [Xbox boot filesystem](../xbox-boot-file-system) and is exposed as a normal NTFS partition via a special driver. |
+| Internal Flash | F:\\        | The flash does not contain a normal file system, it is using the [Xbox boot filesystem](xbox-boot-file-system.md) and is exposed as a normal NTFS partition via a special driver. |
 | host.xvd       | C:\\        | Host's Windows Installation.                                                                                                                                                                                          |
 | User Content   | E:\\        | Direct access to the HDD User Content partition. XVCs are stored here.                                                                                                                                                |
 | System Update  | R:\\        | Direct access to the HDD System Update partition. Boot slots and SystemOS XVDs.                                                                                                                                       |

--- a/docs/xcrdutil.md
+++ b/docs/xcrdutil.md
@@ -9,7 +9,7 @@ The tool is located at `C:\Windows\System32\xcrdutil.exe`
 XCRDutil allows specifying remote paths, in HostOS, via two notations:
 
 - XCRD paths (see below, e.g. `[XUC:]\package.xvd` for **User Content** partition in HostOS). These paths are an abstraction to the HostOS filesystem, allowing to refer to .xvd's without knowing their exact location, and possibly also allowing for security / permission checks.
-- Global paths (e.g. `\??\F:\` for **F:** / [XBFS](../xbox-boot-file-system) drive in HostOS). These refer to a physical volume (like a disk partition, the flash, etc) in HostOS.
+- Global paths (e.g. `\??\F:\` for **F:** / [XBFS](xbox-boot-file-system.md) drive in HostOS). These refer to a physical volume (like a disk partition, the flash, etc) in HostOS.
 
 Not all the options/arguments for XCRDUtil expect the same format for the paths. Some options are able to work with paths pointing to the SystemOS's filesystem, while others may only work with remote paths to HostOS, in either one of the two types just specified previously:
 

--- a/docs/xct.md
+++ b/docs/xct.md
@@ -1,5 +1,5 @@
 # XCT
-Unknown usecase, related to [XVD files](../xbox-virtual-disk).
+Unknown usecase, related to [XVD files](../xbox-virtual-drive/).
 
 ## File format
 

--- a/docs/xct.md
+++ b/docs/xct.md
@@ -1,5 +1,5 @@
 # XCT
-Unknown usecase, related to [XVD files](../xbox-virtual-drive/).
+Unknown usecase, related to [XVD files](xbox-virtual-drive.md).
 
 ## File format
 

--- a/docs/xvi.md
+++ b/docs/xvi.md
@@ -1,5 +1,5 @@
 # Xvi files
-Some sort of metadata file related to [XVD files](../xbox-virtual-drive/), stored next to downloaded xvd files on the hard drive.
+Some sort of metadata file related to [XVD files](xbox-virtual-drive.md), stored next to downloaded xvd files on the hard drive.
 
 ## File format
 Total size: 0x1000

--- a/docs/xvi.md
+++ b/docs/xvi.md
@@ -1,5 +1,5 @@
 # Xvi files
-Some sort of metadata file related to [XVD files](../xbox-virtual-disk), stored next to downloaded xvd files on the hard drive.
+Some sort of metadata file related to [XVD files](../xbox-virtual-drive/), stored next to downloaded xvd files on the hard drive.
 
 ## File format
 Total size: 0x1000


### PR DESCRIPTION
Should have been one commit but I got distracted...

When running locally these are the only remaining errors, however I did not modify these files, so previous commits broke them I guess.

```bash
WARNING -  Doc file 'dev-portal-api/device-portal-pages.md' contains a relative link '../debug-test-perf/device-portal.md', but the target 'debug-test-perf/device-portal.md' is not found among documentation files.
INFO    -  Doc file 'dev-portal-api/device-portal-pages.md' contains an absolute link '/gaming/xbox-live/xbox-live-service-configuration.md#get-your-ids', it was left as is.
WARNING -  Doc file 'dev-portal-api/device-portal-pages.md' contains a relative link '../xbox-apps/uwp-fiddler.md', but the target 'xbox-apps/uwp-fiddler.md' is not found among documentation files.
WARNING -  Doc file 'dev-portal-api/device-portal-pages.md' contains a relative link 'images/device-portal-xbox-22.PNG', but the target 'dev-portal-api/images/device-portal-xbox-22.PNG' is not found among documentation files.
```