### PR TITLE
Document oddity about Day-1 Xbox One ODD

### DIFF
--- a/docs/optical-disc-drive/odd-firmware-update-log.md
+++ b/docs/optical-disc-drive/odd-firmware-update-log.md
@@ -1,5 +1,411 @@
 ## ODD Update Log Variants
-Created on HDD by dashboard-update, placed unencrypted on NTFS partition
+
+### Day-1 Xbox One console ODD update log in another console (thanks to anonymous donnor)
+The first batches of Xbox One Consoles that made it into the shelves in 2013, apparently did not contain a production-ready firmware for the optical disc drive. Hence, their internal memory was unlocked and could be read/writen. The drives were still paired to the console they shipped with, so it was not possible to use them with another console, but would have been useful for DVD/ODD firmware research. After the day-1 update these drives would be update and locked. Here's the log of one of those drives being plugged to a different console:
+
+```
+ODDFW update sequence: 0.
+FOUND DeviceInstance AHCI\Port\0
+Got PDO: \Device\00000017
+Drive type detected: Elk.
+Drive is Unlocked!
+Nvkey is Programmed!
+Found firmware FW_0001.bin.
+ExclusiveState : None
+CallerName: 
+MenuId: 0xC2, DevId1: 0x20, DevId2: 0x14
+Flash type detected: MXIC(MX25L8091E).
+Erasing sector at offset 00001000
+Programming sector at offset 00001000
+Erasing sector at offset 00002000
+Programming sector at offset 00002000
+Erasing sector at offset 00003000
+Programming sector at offset 00003000
+Erasing sector at offset 00004000
+Programming sector at offset 00004000
+Erasing sector at offset 00005000
+Programming sector at offset 00005000
+Erasing sector at offset 00006000
+Programming sector at offset 00006000
+Erasing sector at offset 00007000
+Programming sector at offset 00007000
+Erasing sector at offset 00008000
+Programming sector at offset 00008000
+Erasing sector at offset 00009000
+Programming sector at offset 00009000
+Erasing sector at offset 0000A000
+Programming sector at offset 0000A000
+Erasing sector at offset 0000B000
+Programming sector at offset 0000B000
+Erasing sector at offset 0000C000
+Programming sector at offset 0000C000
+Erasing sector at offset 0000D000
+Programming sector at offset 0000D000
+Erasing sector at offset 0000E000
+Programming sector at offset 0000E000
+Erasing sector at offset 0000F000
+Programming sector at offset 0000F000
+Erasing sector at offset 00010000
+Programming sector at offset 00010000
+Erasing sector at offset 00011000
+Programming sector at offset 00011000
+Erasing sector at offset 00012000
+Programming sector at offset 00012000
+Erasing sector at offset 00013000
+Programming sector at offset 00013000
+Erasing sector at offset 00014000
+Programming sector at offset 00014000
+Erasing sector at offset 00015000
+Programming sector at offset 00015000
+Erasing sector at offset 00016000
+Programming sector at offset 00016000
+Erasing sector at offset 00017000
+Programming sector at offset 00017000
+Erasing sector at offset 00018000
+Programming sector at offset 00018000
+Erasing sector at offset 00019000
+Programming sector at offset 00019000
+Erasing sector at offset 0001A000
+Programming sector at offset 0001A000
+Erasing sector at offset 0001B000
+Programming sector at offset 0001B000
+Erasing sector at offset 0001C000
+Programming sector at offset 0001C000
+Erasing sector at offset 0001D000
+Programming sector at offset 0001D000
+Erasing sector at offset 0001E000
+Programming sector at offset 0001E000
+Erasing sector at offset 0001F000
+Programming sector at offset 0001F000
+Erasing sector at offset 00020000
+Programming sector at offset 00020000
+Erasing sector at offset 00021000
+Programming sector at offset 00021000
+Erasing sector at offset 00022000
+Programming sector at offset 00022000
+Erasing sector at offset 00023000
+Programming sector at offset 00023000
+Erasing sector at offset 00024000
+Programming sector at offset 00024000
+Erasing sector at offset 00025000
+Programming sector at offset 00025000
+Erasing sector at offset 00026000
+Programming sector at offset 00026000
+Erasing sector at offset 00027000
+Programming sector at offset 00027000
+Erasing sector at offset 00028000
+Programming sector at offset 00028000
+Erasing sector at offset 00029000
+Programming sector at offset 00029000
+Erasing sector at offset 0002A000
+Programming sector at offset 0002A000
+Erasing sector at offset 0002B000
+Programming sector at offset 0002B000
+Erasing sector at offset 0002C000
+Programming sector at offset 0002C000
+Erasing sector at offset 0002D000
+Programming sector at offset 0002D000
+Erasing sector at offset 0002E000
+Programming sector at offset 0002E000
+Erasing sector at offset 0002F000
+Programming sector at offset 0002F000
+Erasing sector at offset 00030000
+Programming sector at offset 00030000
+Erasing sector at offset 00031000
+Programming sector at offset 00031000
+Erasing sector at offset 00032000
+Programming sector at offset 00032000
+Erasing sector at offset 00033000
+Programming sector at offset 00033000
+Erasing sector at offset 00034000
+Programming sector at offset 00034000
+Erasing sector at offset 00035000
+Programming sector at offset 00035000
+Erasing sector at offset 00036000
+Programming sector at offset 00036000
+Erasing sector at offset 00037000
+Programming sector at offset 00037000
+Erasing sector at offset 00038000
+Programming sector at offset 00038000
+Erasing sector at offset 00039000
+Programming sector at offset 00039000
+Erasing sector at offset 0003A000
+Programming sector at offset 0003A000
+Erasing sector at offset 0003B000
+Programming sector at offset 0003B000
+Erasing sector at offset 0003C000
+Programming sector at offset 0003C000
+Erasing sector at offset 0003D000
+Programming sector at offset 0003D000
+Erasing sector at offset 0003E000
+Programming sector at offset 0003E000
+Erasing sector at offset 0003F000
+Programming sector at offset 0003F000
+Erasing sector at offset 00040000
+Programming sector at offset 00040000
+Erasing sector at offset 00041000
+Programming sector at offset 00041000
+Erasing sector at offset 00042000
+Programming sector at offset 00042000
+Erasing sector at offset 00043000
+Programming sector at offset 00043000
+Erasing sector at offset 00044000
+Programming sector at offset 00044000
+Erasing sector at offset 00045000
+Programming sector at offset 00045000
+Erasing sector at offset 00046000
+Programming sector at offset 00046000
+Erasing sector at offset 00047000
+Programming sector at offset 00047000
+Erasing sector at offset 00048000
+Programming sector at offset 00048000
+Erasing sector at offset 00049000
+Programming sector at offset 00049000
+Erasing sector at offset 0004A000
+Programming sector at offset 0004A000
+Erasing sector at offset 0004B000
+Programming sector at offset 0004B000
+Erasing sector at offset 0004C000
+Programming sector at offset 0004C000
+Erasing sector at offset 0004D000
+Programming sector at offset 0004D000
+Erasing sector at offset 0004E000
+Programming sector at offset 0004E000
+Erasing sector at offset 0004F000
+Programming sector at offset 0004F000
+Erasing sector at offset 00050000
+Programming sector at offset 00050000
+Erasing sector at offset 00051000
+Programming sector at offset 00051000
+Erasing sector at offset 00052000
+Programming sector at offset 00052000
+Erasing sector at offset 00053000
+Programming sector at offset 00053000
+Erasing sector at offset 00054000
+Programming sector at offset 00054000
+Erasing sector at offset 00055000
+Programming sector at offset 00055000
+Erasing sector at offset 00056000
+Programming sector at offset 00056000
+Erasing sector at offset 00057000
+Programming sector at offset 00057000
+Erasing sector at offset 00058000
+Programming sector at offset 00058000
+Erasing sector at offset 00059000
+Programming sector at offset 00059000
+Erasing sector at offset 0005A000
+Programming sector at offset 0005A000
+Erasing sector at offset 0005B000
+Programming sector at offset 0005B000
+Erasing sector at offset 0005C000
+Programming sector at offset 0005C000
+Erasing sector at offset 0005D000
+Programming sector at offset 0005D000
+Erasing sector at offset 0005E000
+Programming sector at offset 0005E000
+Erasing sector at offset 0005F000
+Programming sector at offset 0005F000
+Erasing sector at offset 00060000
+Programming sector at offset 00060000
+Erasing sector at offset 00061000
+Programming sector at offset 00061000
+Erasing sector at offset 00062000
+Programming sector at offset 00062000
+Erasing sector at offset 00063000
+Programming sector at offset 00063000
+Erasing sector at offset 00064000
+Programming sector at offset 00064000
+Erasing sector at offset 00065000
+Programming sector at offset 00065000
+Erasing sector at offset 00066000
+Programming sector at offset 00066000
+Erasing sector at offset 00067000
+Programming sector at offset 00067000
+Erasing sector at offset 00068000
+Programming sector at offset 00068000
+Erasing sector at offset 00069000
+Programming sector at offset 00069000
+Erasing sector at offset 0006A000
+Programming sector at offset 0006A000
+Erasing sector at offset 0006B000
+Programming sector at offset 0006B000
+Erasing sector at offset 0006C000
+Programming sector at offset 0006C000
+Erasing sector at offset 0006D000
+Programming sector at offset 0006D000
+Erasing sector at offset 0006E000
+Programming sector at offset 0006E000
+Erasing sector at offset 0006F000
+Programming sector at offset 0006F000
+Erasing sector at offset 00070000
+Programming sector at offset 00070000
+Erasing sector at offset 00071000
+Programming sector at offset 00071000
+Erasing sector at offset 00072000
+Programming sector at offset 00072000
+Erasing sector at offset 00073000
+Programming sector at offset 00073000
+Erasing sector at offset 00074000
+Programming sector at offset 00074000
+Erasing sector at offset 00075000
+Programming sector at offset 00075000
+Erasing sector at offset 00076000
+Programming sector at offset 00076000
+Erasing sector at offset 00077000
+Programming sector at offset 00077000
+Erasing sector at offset 00078000
+Programming sector at offset 00078000
+Erasing sector at offset 00079000
+Programming sector at offset 00079000
+Erasing sector at offset 0007A000
+Programming sector at offset 0007A000
+Erasing sector at offset 0007B000
+Programming sector at offset 0007B000
+Erasing sector at offset 0007C000
+Programming sector at offset 0007C000
+Erasing sector at offset 0007D000
+Programming sector at offset 0007D000
+Erasing sector at offset 0007E000
+Programming sector at offset 0007E000
+Erasing sector at offset 0007F000
+Programming sector at offset 0007F000
+Erasing sector at offset 00080000
+Programming sector at offset 00080000
+Erasing sector at offset 00081000
+Programming sector at offset 00081000
+Erasing sector at offset 00082000
+Programming sector at offset 00082000
+Erasing sector at offset 00083000
+Programming sector at offset 00083000
+Erasing sector at offset 00084000
+Programming sector at offset 00084000
+Erasing sector at offset 00085000
+Programming sector at offset 00085000
+Erasing sector at offset 00086000
+Programming sector at offset 00086000
+Erasing sector at offset 00087000
+Programming sector at offset 00087000
+Erasing sector at offset 00088000
+Programming sector at offset 00088000
+Erasing sector at offset 00089000
+Programming sector at offset 00089000
+Erasing sector at offset 0008A000
+Programming sector at offset 0008A000
+Erasing sector at offset 0008B000
+Programming sector at offset 0008B000
+Erasing sector at offset 0008C000
+Programming sector at offset 0008C000
+Erasing sector at offset 0008D000
+Programming sector at offset 0008D000
+Erasing sector at offset 0008E000
+Programming sector at offset 0008E000
+Erasing sector at offset 0008F000
+Programming sector at offset 0008F000
+Erasing sector at offset 00090000
+Programming sector at offset 00090000
+Erasing sector at offset 00091000
+Programming sector at offset 00091000
+Erasing sector at offset 00092000
+Programming sector at offset 00092000
+Erasing sector at offset 00093000
+Programming sector at offset 00093000
+Erasing sector at offset 00094000
+Programming sector at offset 00094000
+Erasing sector at offset 00095000
+Programming sector at offset 00095000
+Erasing sector at offset 00096000
+Programming sector at offset 00096000
+Erasing sector at offset 00097000
+Programming sector at offset 00097000
+Erasing sector at offset 00098000
+Programming sector at offset 00098000
+Erasing sector at offset 00099000
+Programming sector at offset 00099000
+Erasing sector at offset 0009A000
+Programming sector at offset 0009A000
+Erasing sector at offset 0009B000
+Programming sector at offset 0009B000
+Erasing sector at offset 0009C000
+Programming sector at offset 0009C000
+Erasing sector at offset 0009D000
+Programming sector at offset 0009D000
+Erasing sector at offset 0009E000
+Programming sector at offset 0009E000
+Erasing sector at offset 0009F000
+Programming sector at offset 0009F000
+Erasing sector at offset 000A0000
+Programming sector at offset 000A0000
+Erasing sector at offset 000A1000
+Programming sector at offset 000A1000
+Erasing sector at offset 000A2000
+Programming sector at offset 000A2000
+Erasing sector at offset 000A3000
+Programming sector at offset 000A3000
+Erasing sector at offset 000A4000
+Programming sector at offset 000A4000
+Erasing sector at offset 000A5000
+Programming sector at offset 000A5000
+Erasing sector at offset 000A6000
+Programming sector at offset 000A6000
+Writing sector 0 ...
+Erasing sector at offset 00000000
+Programming sector at offset 00000000
+ExclusiveState : Exclusive
+CallerName: COddDriverApi
+Powering off ODD ...
+ODD status = 87
+ODD status = 02
+Powering on ODD ...
+ODD status = 02
+ODD status = 87
+Wait more time for ODD to be on ...
+FOUND DeviceInstance AHCI\Port\0
+Got PDO: \Device\00000017
+Auth IOCTL 000240C4 failed, error = e0e80085
+IOddDriverApi::DriveAuthPowerOn failed
+DriveAuth failed, try one more reboot
+Powering off ODD ...
+ODD status = 87
+ODD status = 02
+Powering on ODD ...
+ODD status = 02
+ODD status = 87
+Wait more time for ODD to be on ...
+FOUND DeviceInstance AHCI\Port\0
+Got PDO: \Device\00000017
+Auth IOCTL 000240C4 failed, error = e0e80085
+IOddDriverApi::DriveAuthPowerOn failed
+DriveAuth failed, try one more reboot
+Post update DriveAuth failed, something went wrong
+OddFirmwareUpdate error 80910008
+FW update failed!!!
+ODDFW update failed, hr = 80910008, retry again in two seconds.
+Found firmware FW_0001.bin.
+Firmware version match, no FW update is needed
+Update is not neccessary.
+Drive is Unlocked!
+Nvkey is Programmed!
+ODD token found in factory settings, consider ODD is paired.
+PV+ console not locked, proceed to lock down.
+LockDown success!
+Auth IOCTL 000240C4 failed, error = e0e80085
+IOddDriverApi::DriveAuthPowerOn failed
+ODDFW update failed, hr = 80910008, retry again in two seconds.
+Found firmware FW_0001.bin.
+Firmware version match, no FW update is needed
+Update is not neccessary.
+Drive is Locked!
+Nvkey is Programmed!
+ODD token found in factory settings, consider ODD is paired.
+PV+ console already locked, skip lock down.
+Auth IOCTL 000240C4 failed, error = e0e80085
+IOddDriverApi::DriveAuthPowerOn failed
+ODDFW update failed, hr = 80910008, retry again in two seconds.
+ODDFW update finished, hr = 80910008
+
+```
+
+### Created on HDD by dashboard-update, placed unencrypted on NTFS partition
 ```
 ODDFW update sequence: 0.
 FOUND DeviceInstance AHCI\Port\0
@@ -18,9 +424,9 @@ Got drive auth status : 2
 ODDFW update finished, hr = 00000000
 ```
 
-Misc Error Logs
+## Misc Error Logs
 
-Typically this happens when you don't have your ODD plugged into the xbox one.
+### Typically this happens when you don't have your ODD plugged into the xbox one.
 ```
 ODDFW update sequence: 0.
 FAILED to find ODD physical device, status = 0xC000000E.
@@ -29,7 +435,7 @@ COddDevice::_Open failed!
 Odd open failed, retry in one second...
 ```
 
-When you run OSUDT or  a System Update you may encounter this. 
+### When you run OSUDT or  a System Update you may encounter this. 
 ```
 ODDFW update failed, hr = 80910002, retry again in two seconds.
 FAILED to find ODD physical device, status = 0xC000000E.
@@ -38,7 +444,7 @@ COddDevice::_Open failed!
 Odd open failed, retry in one second...
 ```
 
-When you plug something in, say a HDD in place of the ODD
+### When you plug something in, say a HDD in place of the ODD
 ```
 ODDFW update sequence: 2.
 FOUND DeviceInstance AHCI\Port\0
@@ -49,7 +455,7 @@ COddDevice::_Open failed!
 Odd open failed, retry in one second...
 ```
 
-If you have a working Xbox One ODD but the ODD is not the married board you'll see this
+### If you have a working Xbox One ODD but the ODD is not the married board you'll see this
 ```
 FOUND DeviceInstance AHCI\Port\0
 Got PDO: \Device\00000017


### PR DESCRIPTION
Adds an update log that was sent anonymously, from a Day-1 Xbox One ODD that was plugged into a different console, showing the drive is unlocked.